### PR TITLE
Clean code - Standardizing single quotes and concatenation

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -10,7 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 import os
-
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -86,14 +85,14 @@ WSGI_APPLICATION = 'config.wsgi.application'
 
 
 # Database# https://docs.djangoproject.com/en/4.1/ref/settings/#databases
-POSTGRES_DB = os.getenv("POSTGRES_DB", "atlas_db")
-POSTGRES_USER = os.getenv("POSTGRES_USER", "leonardogomes")
+POSTGRES_DB = os.getenv('POSTGRES_DB', 'atlas_db')
+POSTGRES_USER = os.getenv('POSTGRES_USER', 'leonardogomes')
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        "NAME": POSTGRES_DB,
-        "USER": POSTGRES_USER,
+        'NAME': POSTGRES_DB,
+        'USER': POSTGRES_USER,
     },
 }
 

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -14,11 +14,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path("state/", include("state.urls")),
-    path("district/", include("district.urls")),
-    path("data/", include("data.urls")),
+    path('state/', include('state.urls')),
+    path('district/', include('district.urls')),
+    path('data/', include('data.urls')),
 ]

--- a/src/data/management/commands/load_data.py
+++ b/src/data/management/commands/load_data.py
@@ -1,10 +1,11 @@
+import json
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+
 from data.models import Data
 from dictionary.models import Dictionary
 
-import os
-import json
-
-from django.core.management.base import BaseCommand, CommandError
 
 class Command(BaseCommand):
     help = 'Import data geojson data'
@@ -17,29 +18,29 @@ class Command(BaseCommand):
         
         
         for helper_path in helper_paths:
-            helper = helper_folder + '/' + helper_path
+            helper = f'{helper_folder}/{helper_path}'
             
             if os.path.exists(helper) is False:
-                raise CommandError('File "%s" does not exist' % helper)
+                raise CommandError(f'File {helper} does not exist')
 
-            self.stdout.write(self.style.SUCCESS('Successfully, file exist "%s"' % helper))
-            self.stdout.write(self.style.NOTICE('Loading "%s" folder' % helper_path.replace(".json", "")))
+            self.stdout.write(self.style.SUCCESS(f'Successfully, file exist {helper}'))
+            self.stdout.write(self.style.NOTICE(f'Loading {helper_path.replace(".json", "")} folder'))
             self.stdout.write(self.style.WARNING('processing...'))
             
         
             with open(helper, 'r') as file:
                 helper_data = json.load(file)
                 
-                folder = 'data/data/' + helper_path.replace(".json", "")
+                folder = f'data/data/{helper_path.replace(".json", "")}'
                 file_paths = os.listdir(folder)
                 
                 for path in file_paths:
-                    file_path = folder + '/' + path
+                    file_path = f'{folder}/{path}'
                     
                     if os.path.exists(file_path) is False:
-                        raise CommandError('File "%s" does not exist' % file_path)
+                        raise CommandError(f'File {file_path} does not exist')
 
-                    self.stdout.write(self.style.SUCCESS('file exist "%s"' % file_path))
+                    self.stdout.write(self.style.SUCCESS(f'file exist {file_path}'))
                     self.stdout.write(self.style.WARNING('processing...'))
                     
                     with open(file_path, 'r') as file:
@@ -47,19 +48,19 @@ class Command(BaseCommand):
                         
                         for id, item in enumerate(data):
                             
-                            dictionary = Dictionary.objects.get(name=path.replace(".json", ""))
+                            dictionary = Dictionary.objects.get(name=path.replace('.json', ''))
                           
                             Data.objects.create(
                                 region_id=helper_data[id],
-                                name=path.replace(".json", ""),
-                                type=helper_path.replace(".json", ""),
+                                name=path.replace('.json', ''),
+                                type=helper_path.replace('.json', ''),
                                 value=item,
                                 dictionary=dictionary,
                             )
                             
-                    self.stdout.write(self.style.HTTP_SUCCESS('Folder "%s" loaded' % path.replace(".json", "")))
+                    self.stdout.write(self.style.HTTP_SUCCESS(f'Folder {path.replace(".json", "")} loaded'))
                     
-            self.stdout.write(self.style.HTTP_SUCCESS('Folder "%s" loaded' % helper_path.replace(".json", "")))
+            self.stdout.write(self.style.HTTP_SUCCESS(f'Folder {helper_path.replace(".json", "")} loaded'))
                     
         self.stdout.write(self.style.SUCCESS('Data loaded :D'))
                 

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from dictionary.models import Dictionary
 
+
 class Data(models.Model):
     region_id = models.IntegerField(
         default=None, 
@@ -10,8 +11,8 @@ class Data(models.Model):
     )
     
     class TypeOptions(models.TextChoices):
-        STATE = "state"
-        DISTRICT = "district"
+        STATE = 'state'
+        DISTRICT = 'district'
         
     type = models.CharField(
         max_length=50,
@@ -36,8 +37,8 @@ class Data(models.Model):
     dictionary = models.ForeignKey(
         Dictionary,
         on_delete=models.CASCADE,
-        related_name="dictionary",
+        related_name='dictionary',
     )
     
     def __str__(self):
-        return self.value + " - " + self.name
+        return f'{self.value}-{self.name}'

--- a/src/data/serializers.py
+++ b/src/data/serializers.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
 
+from dictionary.serializers import DictionarySerializer
+
 from .models import Data
 
-from dictionary.serializers import DictionarySerializer
 
 class DataSerializer(serializers.ModelSerializer):    
     dictionary = DictionarySerializer(read_only=True)
@@ -10,9 +11,9 @@ class DataSerializer(serializers.ModelSerializer):
     class Meta:
         model = Data
         fields = [
-            "region_id",
-            "name",
-            "value",
-            "type",
-            "dictionary",
+            'region_id',
+            'name',
+            'value',
+            'type',
+            'dictionary',
         ]

--- a/src/data/urls.py
+++ b/src/data/urls.py
@@ -1,13 +1,13 @@
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework_nested import routers
 
-from .views import DataStateViewSet, DataDistrictViewSet
+from .views import DataDistrictViewSet, DataStateViewSet
 
 router = routers.DefaultRouter()
 
-router.register("state", DataStateViewSet, basename='Date state')
-router.register("district", DataDistrictViewSet, basename='Date district')
+router.register('state', DataStateViewSet, basename='Date state')
+router.register('district', DataDistrictViewSet, basename='Date district')
 
 urlpatterns = [
-    path("", include(router.urls)),
+    path('', include(router.urls)),
 ]

--- a/src/data/views.py
+++ b/src/data/views.py
@@ -3,12 +3,13 @@ from rest_framework import viewsets
 from .models import Data
 from .serializers import DataSerializer
 
+
 class DataStateViewSet(viewsets.ModelViewSet):
     serializer_class = DataSerializer
 
     def get_queryset(self):
         region_id = self.request.query_params.get('region_id')
-        queryset = Data.objects.filter(type="state")
+        queryset = Data.objects.filter(type='state')
         if region_id is not None:
             queryset = queryset.filter(region_id=region_id)
         return queryset
@@ -18,7 +19,7 @@ class DataDistrictViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         region_id = self.request.query_params.get('region_id')
-        queryset = Data.objects.filter(type="district")
+        queryset = Data.objects.filter(type='district')
         if region_id is not None:
             queryset = queryset.filter(region_id=region_id)
         return queryset

--- a/src/dictionary/management/commands/load_dict.py
+++ b/src/dictionary/management/commands/load_dict.py
@@ -1,9 +1,10 @@
-from dictionary.models import Dictionary
-
-import os
 import json
+import os
 
 from django.core.management.base import BaseCommand, CommandError
+
+from dictionary.models import Dictionary
+
 
 class Command(BaseCommand):
     help = 'Import dictionary geojson data'
@@ -15,12 +16,12 @@ class Command(BaseCommand):
         file_paths = os.listdir(folder)
         
         for path in file_paths:
-            file_path = folder + '/' + path
+            file_path = f'{folder}/{path}'
             
             if os.path.exists(file_path) is False:
-                raise CommandError('File "%s" does not exist' % file_path)
+                raise CommandError(f'File {file_path} does not exist')
 
-            self.stdout.write(self.style.SUCCESS('Successfully, file exist "%s"' % file_path))
+            self.stdout.write(self.style.SUCCESS(f'Successfully, file exist {file_path}'))
             self.stdout.write(self.style.WARNING('processing...'))
         
             with open(file_path, 'r') as file:
@@ -46,7 +47,7 @@ class Command(BaseCommand):
                         unit= unit
                     )
             
-                    self.stdout.write(self.style.HTTP_SUCCESS('"%s" loaded' % name))
+                    self.stdout.write(self.style.HTTP_SUCCESS(f'{name} loaded'))
                 
         self.stdout.write(self.style.SUCCESS('Data loaded :D'))
                 

--- a/src/dictionary/models.py
+++ b/src/dictionary/models.py
@@ -1,6 +1,6 @@
 from django.db import models
-
 from django.utils.translation import gettext_lazy as _
+
 
 class Dictionary(models.Model):
     name = models.CharField(
@@ -17,11 +17,11 @@ class Dictionary(models.Model):
     )
     
     class FormatOptions(models.TextChoices):
-        INT = "INT"
-        FLOAT2 = "FLOAT2"
-        GRAPHIC = "GRAPHIC"
-        PROGRESS_BAR = "PROGRESS_BAR"
-        STRING = "STRING"
+        INT = 'INT'
+        FLOAT2 = 'FLOAT2'
+        GRAPHIC = 'GRAPHIC'
+        PROGRESS_BAR = 'PROGRESS_BAR'
+        STRING = 'STRING'
         
     format = models.CharField(
         max_length=12,
@@ -30,16 +30,16 @@ class Dictionary(models.Model):
     ) 
     
     class ClassificationOptions(models.TextChoices):
-        HEALTH = "Sa", _("Saúde")
-        EDUCATION = "Ed", _("Educação")
-        ECONOMY = "Ec", _("Economia")
-        MOBILITY = "Mo", _("Mobilidade")
-        DEMOGRAPHIC = "De", _("Demografia")
-        ENVIRONMENT = "Me", _("Meio Ambiente")
-        URBANISM = "Ur", _("Urbanismo")
-        SECURITY = "Se", _("Segurança")
-        ENTREPRENEURSHIP = "Em", _("Empreendedorismo")
-        TECNOLOGY = "Te", _("Tecnologia")
+        HEALTH = 'Sa', _('Saúde')
+        EDUCATION = 'Ed', _('Educação')
+        ECONOMY = 'Ec', _('Economia')
+        MOBILITY = 'Mo', _('Mobilidade')
+        DEMOGRAPHIC = 'De', _('Demografia')
+        ENVIRONMENT = 'Me', _('Meio Ambiente')
+        URBANISM = 'Ur', _('Urbanismo')
+        SECURITY = 'Se', _('Segurança')
+        ENTREPRENEURSHIP = 'Em', _('Empreendedorismo')
+        TECNOLOGY = 'Te', _('Tecnologia')
         
     classification = models.CharField(
         max_length=2,
@@ -61,14 +61,14 @@ class Dictionary(models.Model):
     )
     
     class UnitOptions(models.TextChoices):
-        MONEY = "M", _("Money")
-        NUMBER = "N", _("Number")
-        DISTANCE = "D", _("Distance")
-        PORCENTAGE = "P", _("Porcentage")
-        SQUARE_KILOMETERS = "K2", _("Square Kilometers")
-        WAGES = "W", _("Wages")
-        INHABITANT_KILOMETERS = "H", _("InhabitantKilometers")
-        MBPS = "MB", _("MBPS")
+        MONEY = 'M', _('Money')
+        NUMBER = 'N', _('Number')
+        DISTANCE = 'D', _('Distance')
+        PORCENTAGE = 'P', _('Porcentage')
+        SQUARE_KILOMETERS = 'K2', _('Square Kilometers')
+        WAGES = 'W', _('Wages')
+        INHABITANT_KILOMETERS = 'H', _('InhabitantKilometers')
+        MBPS = 'MB', _('MBPS')
        
     unit = models.CharField(
         max_length=2,

--- a/src/dictionary/serializers.py
+++ b/src/dictionary/serializers.py
@@ -2,16 +2,17 @@ from rest_framework import serializers
 
 from .models import Dictionary
 
+
 class DictionarySerializer(serializers.ModelSerializer):    
     
     class Meta:
         model = Dictionary
         fields = [
-            "name",
-            "agency",
-            "format",
-            "classification",
-            "description",
-            "label",
-            "unit",
+            'name',
+            'agency',
+            'format',
+            'classification',
+            'description',
+            'label',
+            'unit',
         ]

--- a/src/district/management/commands/load_dist.py
+++ b/src/district/management/commands/load_dist.py
@@ -1,10 +1,11 @@
+import json
+import os
+
+from django.contrib.gis.geos import GEOSGeometry
+from django.core.management.base import BaseCommand, CommandError
+
 from district.models import District
 
-import os
-import json
-from django.contrib.gis.geos import GEOSGeometry
-
-from django.core.management.base import BaseCommand, CommandError
 
 class Command(BaseCommand):
     help = 'Import district geojson data'
@@ -16,12 +17,12 @@ class Command(BaseCommand):
         file_paths = os.listdir(folder)
         
         for path in file_paths:
-            file_path = folder + '/' + path
+            file_path = f'{folder}/{path}'
             
             if os.path.exists(file_path) is False:
-                raise CommandError('File "%s" does not exist' % file_path)
+                raise CommandError(f'File {file_path} does not exist')
 
-            self.stdout.write(self.style.SUCCESS('Successfully, file exist "%s"' % file_path))
+            self.stdout.write(self.style.SUCCESS(f'Successfully, file exist {file_path}'))
             self.stdout.write(self.style.WARNING('processing...'))
         
             with open(file_path, 'r') as file:
@@ -30,10 +31,10 @@ class Command(BaseCommand):
             
                     geo_type = feature['type']
                     
-                    geo_id = feature['properties']["CD_MUN"]
-                    geo_name = feature['properties']["NM_MUN"]
-                    geo_code = feature['properties']["SIGLA_UF"]
-                    geo_region = feature['properties']["AREA_KM2"]
+                    geo_id = feature['properties']['CD_MUN']
+                    geo_name = feature['properties']['NM_MUN']
+                    geo_code = feature['properties']['SIGLA_UF']
+                    geo_region = feature['properties']['AREA_KM2']
                     
                     if feature['geometry']['type'] == 'Polygon':
                         feature['geometry']['type'] = 'MultiPolygon'
@@ -51,7 +52,7 @@ class Command(BaseCommand):
                         AREA_KM2= geo_region
                     )
             
-            self.stdout.write(self.style.HTTP_SUCCESS('"%s" loaded' % file_path))
+            self.stdout.write(self.style.HTTP_SUCCESS(f'{file_path} loaded'))
                 
         self.stdout.write(self.style.SUCCESS('Data loaded :D'))
                 

--- a/src/district/models.py
+++ b/src/district/models.py
@@ -1,14 +1,15 @@
 from django.contrib.gis.db import models
 
+
 class District(models.Model):
     name = models.CharField(
         max_length=255, 
-        default="district",
+        default='district',
     )
     
     type = models.CharField(
         max_length=255, 
-        default="Feature"
+        default='Feature'
     )
     
     geometry = models.MultiPolygonField(

--- a/src/district/serializers.py
+++ b/src/district/serializers.py
@@ -2,14 +2,15 @@ from rest_framework_gis import serializers
 
 from .models import District
 
+
 class DistrictSerializer(serializers.GeoFeatureModelSerializer):    
     
     class Meta:
         model = District
         geo_field = 'geometry'
         fields = [
-            "CD_MUN",
-            "NM_MUN",
-            "SIGLA_UF",
-            "AREA_KM2",
+            'CD_MUN',
+            'NM_MUN',
+            'SIGLA_UF',
+            'AREA_KM2',
         ]

--- a/src/district/urls.py
+++ b/src/district/urls.py
@@ -1,12 +1,12 @@
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework_nested import routers
 
 from .views import DistrictViewSet
 
 router = routers.DefaultRouter()
 
-router.register("geojson", DistrictViewSet, basename='District')
+router.register('geojson', DistrictViewSet, basename='District')
 
 urlpatterns = [
-    path("", include(router.urls)),
+    path('', include(router.urls)),
 ]

--- a/src/manage.py
+++ b/src/manage.py
@@ -11,9 +11,9 @@ def main():
         from django.core.management import execute_from_command_line
     except ImportError as exc:
         raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
+            'Couldn\'t import Django. Are you sure it\'s installed and '
+            'available on your PYTHONPATH environment variable? Did you '
+            'forget to activate a virtual environment?'
         ) from exc
     execute_from_command_line(sys.argv)
 

--- a/src/state/models.py
+++ b/src/state/models.py
@@ -1,14 +1,15 @@
 from django.contrib.gis.db import models
 
+
 class State(models.Model):
     name = models.CharField(
         max_length=255, 
-        default="state"
+        default='state'
     )
     
     type = models.CharField(
         max_length=255, 
-        default="Feature"
+        default='Feature'
     )
     
     geometry = models.MultiPolygonField(

--- a/src/state/serializers.py
+++ b/src/state/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework_gis import serializers
 
-
 from .models import State
+
 
 class StateSerializer(serializers.GeoFeatureModelSerializer):
     
@@ -9,9 +9,9 @@ class StateSerializer(serializers.GeoFeatureModelSerializer):
         model = State
         geo_field = 'geometry'
         fields = [
-            "CD_UF",
-            "POPULATION",
-            "NM_UF",
-            "SIGLA_UF",
-            "NM_REGIAO"
+            'CD_UF',
+            'POPULATION',
+            'NM_UF',
+            'SIGLA_UF',
+            'NM_REGIAO'
         ]

--- a/src/state/urls.py
+++ b/src/state/urls.py
@@ -1,12 +1,12 @@
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework_nested import routers
 
 from .views import StateViewSet
 
 router = routers.DefaultRouter()
 
-router.register("geojson", StateViewSet)
+router.register('geojson', StateViewSet)
 
 urlpatterns = [
-    path("", include(router.urls)),
+    path('', include(router.urls)),
 ]


### PR DESCRIPTION
## Motivation

- According to the PEP8 naming conventions ( is a style guide that describes the coding standards for Python), single quotes and double quotes are treated the same (just pick one and be consistent).

- String Concatenation using f-string
From Python 3.6+, we can use f-string for string concatenation too. It’s a new way to format strings and introduced in [PEP 498 - Literal String Interpolation](https://www.python.org/dev/peps/pep-0498/).

## Changes

- All the files that are using double quotes to single quotes
- All the files that are not using f-string concatenation

## Status Checklist

- [x] All files using single quotes
- [x] All files using f-string

## Testing

- View all files that use quotes or concatenations
